### PR TITLE
Set ssl_verify to True

### DIFF
--- a/satellite-inventory.py
+++ b/satellite-inventory.py
@@ -81,11 +81,10 @@ class SatelliteInventory(object):
         # Read settings and parse CLI arguments
         self.read_settings()
         self.parse_cli_args()
-        
-        self.post_headers = {'content-type': 'application/json'}
-        self.ssl_verify = False
 
-        
+        self.post_headers = {'content-type': 'application/json'}
+        self.ssl_verify = True
+
         self.org = self.get_json(self.sat_api + "organizations?search=" + self._org_name)
         #self.org = self.get_json(self.sat_api + "organizations?search=" + "Foo")
         #print self.org['results'][0]['name']


### PR DESCRIPTION
When communicating with Sat6, ssl_verify=True works for me and doesn't throw
a warning, which is always nice :)
